### PR TITLE
GitHub Action for unit tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,46 @@
+name: Go
+
+on: [push, pull_request]
+
+jobs:
+  test-and-lint:
+    strategy:
+      matrix:
+        go-version: [1.14.x, 1.15.x]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v1
+    - name: Environment information
+      run: |
+        go version
+        go env
+    - name: Vet
+      if: matrix.platform == 'ubuntu-latest'
+      run: go vet -v ./...
+    - name: Lint
+      if: matrix.platform == 'ubuntu-latest'
+      run: |
+        export PATH=$PATH:$(go env GOPATH)/bin
+        go get -u golang.org/x/lint/golint
+        golint -set_exit_status ./...
+    - name: staticcheck.io
+      if: matrix.platform == 'ubuntu-latest'
+      run: |
+        export PATH=$PATH:$(go env GOPATH)/bin
+        go get honnef.co/go/tools/cmd/staticcheck
+        staticcheck -checks all ./...
+    - name: gofumports formatting
+      if: matrix.platform == 'ubuntu-latest'
+      run: |
+        export PATH=$PATH:$(go env GOPATH)/bin
+        go get mvdan.cc/gofumpt/gofumports
+        gofumports -d .
+        [ -z "$(gofumports -l .)" ]
+    - name: Test
+      run: go test -race -count=1 ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
   test-and-lint:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.15.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,4 @@
+// Package config provides configuration reading functionality
 package config
 
 import (

--- a/config/config.go
+++ b/config/config.go
@@ -9,17 +9,20 @@ import (
 	"github.com/influxdata/toml"
 )
 
+// Config defines the main config structure
 type Config struct {
 	WiresX WiresX `toml:"wiresx"`
 	Influx Influx `toml:"influx"`
 }
 
+// WiresX defines the logfile config
 type WiresX struct {
 	Logfile         string `toml:"logfile"`
 	IngestWholeFile bool   `toml:"ingest_whole_file"`
 	Timezone        string `toml:"timezone"`
 }
 
+// Influx defines the influx related config
 type Influx struct {
 	Server       string `toml:"server"`
 	AuthToken    string `toml:"auth_token"`
@@ -30,6 +33,7 @@ type Influx struct {
 	Repeater string `toml:"repeater"`
 }
 
+// Read parses the config file and returns the config structure
 func Read(path string) (*Config, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Package config provides configuration reading functionality
+// Package config provides configuration reading functionality.
 package config
 
 import (
@@ -9,20 +9,20 @@ import (
 	"github.com/influxdata/toml"
 )
 
-// Config defines the main config structure
+// Config defines the main config structure.
 type Config struct {
 	WiresX WiresX `toml:"wiresx"`
 	Influx Influx `toml:"influx"`
 }
 
-// WiresX defines the logfile config
+// WiresX defines the logfile config.
 type WiresX struct {
 	Logfile         string `toml:"logfile"`
 	IngestWholeFile bool   `toml:"ingest_whole_file"`
 	Timezone        string `toml:"timezone"`
 }
 
-// Influx defines the influx related config
+// Influx defines the influx related config.
 type Influx struct {
 	Server       string `toml:"server"`
 	AuthToken    string `toml:"auth_token"`
@@ -33,7 +33,7 @@ type Influx struct {
 	Repeater string `toml:"repeater"`
 }
 
-// Read parses the config file and returns the config structure
+// Read parses the config file and returns the config structure.
 func Read(path string) (*Config, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,52 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/hb9tf/wiresx2influx/config"
+)
+
+func TestRead(t *testing.T) {
+	tests := map[string]struct {
+		inputfile string
+		expected  *config.Config
+	}{
+		"empty config": {
+			inputfile: "testdata/test0.toml",
+			expected: &config.Config{
+				WiresX: config.WiresX{},
+				Influx: config.Influx{},
+			},
+		},
+		"example config": {
+			inputfile: "testdata/test1.toml",
+			expected: &config.Config{
+				WiresX: config.WiresX{
+					Logfile:         "logfile.log",
+					IngestWholeFile: false,
+					Timezone:        "Europe/Zurich",
+				},
+				Influx: config.Influx{
+					Server:       "http://127.0.0.1:9999",
+					AuthToken:    "xyz",
+					Organization: "someorg",
+					Bucket:       "somebucket",
+					Repeater:     "somename",
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := config.Read(tc.inputfile)
+			if err != nil {
+				t.Errorf("Read('%s') returned an error: %v", tc.inputfile, err)
+			}
+			if diff := deep.Equal(tc.expected, got); diff != nil {
+				t.Errorf("Read('%s') returns unexpected result, diff: %v", tc.inputfile, diff)
+			}
+		})
+	}
+}

--- a/config/testdata/test0.toml
+++ b/config/testdata/test0.toml
@@ -1,0 +1,1 @@
+# empty file

--- a/config/testdata/test1.toml
+++ b/config/testdata/test1.toml
@@ -1,0 +1,11 @@
+[wiresx]
+logfile = "logfile.log"
+ingest_whole_file = false
+timezone = "Europe/Zurich"
+
+[influx]
+server = "http://127.0.0.1:9999"
+auth_token = "xyz"
+organization = "someorg"
+bucket = "somebucket"
+repeater = "somename"

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-test/deep v1.0.7
 	github.com/hpcloud/tail v1.0.0
 	github.com/influxdata/influxdb-client-go v1.0.0
 	github.com/influxdata/toml v0.0.0-20180607005434-2a2e3012f7cf

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
+github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/influxdata/influxdb-client-go v1.0.0 h1:SfZUHnqqXn5oPoPZFt138NnFiQPLIgM9GZ3VOkj6ig4=

--- a/influx/influx.go
+++ b/influx/influx.go
@@ -1,4 +1,4 @@
-// Package influx provides InfluxDB feeding
+// Package influx provides InfluxDB feeding.
 package influx
 
 import (
@@ -10,7 +10,7 @@ import (
 	influxdb2 "github.com/influxdata/influxdb-client-go"
 )
 
-// Feed reads log entries from the channel and writes them to InfluxDB
+// Feed reads log entries from the channel and writes them to InfluxDB.
 func Feed(ctx context.Context, logChan chan *wiresx.Log, api influxdb2.WriteApiBlocking, influxTags map[string]string) {
 	for l := range logChan {
 		log.Printf("%s: Message from %q (%s)\n", l.Timestamp, l.Callsign, l.Dev.InferDevice())

--- a/influx/influx.go
+++ b/influx/influx.go
@@ -1,3 +1,4 @@
+// Package influx provides InfluxDB feeding
 package influx
 
 import (

--- a/influx/influx.go
+++ b/influx/influx.go
@@ -10,6 +10,7 @@ import (
 	influxdb2 "github.com/influxdata/influxdb-client-go"
 )
 
+// Feed reads log entries from the channel and writes them to InfluxDB
 func Feed(ctx context.Context, logChan chan *wiresx.Log, api influxdb2.WriteApiBlocking, influxTags map[string]string) {
 	for l := range logChan {
 		log.Printf("%s: Message from %q (%s)\n", l.Timestamp, l.Callsign, l.Dev.InferDevice())

--- a/wiresx/wiresx.go
+++ b/wiresx/wiresx.go
@@ -1,3 +1,4 @@
+// Package wiresx provides wiresx log tailing and parsing
 package wiresx
 
 import (

--- a/wiresx/wiresx.go
+++ b/wiresx/wiresx.go
@@ -2,8 +2,8 @@ package wiresx
 
 import (
 	"fmt"
+	"io"
 	"log"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -156,9 +156,9 @@ func parseLogline(line string, timeLoc *time.Location) (*Log, error) {
 }
 
 func TailLog(path string, ingestWholeFile bool, loc *time.Location, logChan chan *Log) error {
-	whence := os.SEEK_END
+	whence := io.SeekEnd
 	if ingestWholeFile {
-		whence = os.SEEK_SET
+		whence = io.SeekStart
 	}
 	t, err := tail.TailFile(path, tail.Config{
 		ReOpen:    true,  // Reopen recreated files (tail -F)

--- a/wiresx/wiresx.go
+++ b/wiresx/wiresx.go
@@ -1,4 +1,4 @@
-// Package wiresx provides WiresX log tailing and parsing
+// Package wiresx provides WiresX log tailing and parsing.
 package wiresx
 
 import (
@@ -31,13 +31,13 @@ var deviceTypes = map[string]string{
 	"R":  "repeater",
 }
 
-// Activity defines an activity
+// Activity defines an activity.
 type Activity string
 
-// Device defines a device type
+// Device defines a device type.
 type Device string
 
-// InferDevice returns a string representation of the device type
+// InferDevice returns a string representation of the device type.
 func (d Device) InferDevice() string {
 	dev := strings.ToUpper(string(d))
 	for k, v := range deviceTypes {
@@ -55,7 +55,7 @@ func (d Device) InferDevice() string {
 	return "node"
 }
 
-// Log defines the data of a WiresX logentry, see also https://github.com/HB9UF/unconfusion
+// Log defines the data of a WiresX logentry, see also https://github.com/HB9UF/unconfusion.
 type Log struct {
 	Callsign    string
 	Dev         Device
@@ -65,7 +65,7 @@ type Log struct {
 	Loc         *Location
 }
 
-// Location defines a position with longitude and latitude
+// Location defines a position with longitude and latitude.
 type Location struct {
 	Lat float64
 	Lon float64
@@ -158,7 +158,7 @@ func parseLogline(line string, timeLoc *time.Location) (*Log, error) {
 	}, nil
 }
 
-// TailLog tails the logfile to parse the loglines and returns log entries into a channel
+// TailLog tails the logfile to parse the loglines and returns log entries into a channel.
 func TailLog(path string, ingestWholeFile bool, loc *time.Location, logChan chan *Log) error {
 	whence := io.SeekEnd
 	if ingestWholeFile {

--- a/wiresx/wiresx.go
+++ b/wiresx/wiresx.go
@@ -1,4 +1,4 @@
-// Package wiresx provides wiresx log tailing and parsing
+// Package wiresx provides WiresX log tailing and parsing
 package wiresx
 
 import (
@@ -16,27 +16,28 @@ const (
 	logTimeFmt = "2006/01/02 15:04:05"
 )
 
-var (
-	deviceTypes = map[string]string{
-		"E0": "FT-1D",
-		"E5": "FT-2D",
-		"EA": "FT-3D",
-		"F0": "FTM-400D",
-		"F5": "FTM-100D",
-		"FA": "FTM-300D",
-		"G0": "FT-991",
-		"H0": "FTM-3200D",
-		"H5": "FT-70D",
-		"HA": "FTM-3207D",
-		"HF": "FTM-7250D",
-		"R":  "repeater",
-	}
-)
+var deviceTypes = map[string]string{
+	"E0": "FT-1D",
+	"E5": "FT-2D",
+	"EA": "FT-3D",
+	"F0": "FTM-400D",
+	"F5": "FTM-100D",
+	"FA": "FTM-300D",
+	"G0": "FT-991",
+	"H0": "FTM-3200D",
+	"H5": "FT-70D",
+	"HA": "FTM-3207D",
+	"HF": "FTM-7250D",
+	"R":  "repeater",
+}
 
+// Activity defines an activity
 type Activity string
 
+// Device defines a device type
 type Device string
 
+// InferDevice returns a string representation of the device type
 func (d Device) InferDevice() string {
 	dev := strings.ToUpper(string(d))
 	for k, v := range deviceTypes {
@@ -54,7 +55,7 @@ func (d Device) InferDevice() string {
 	return "node"
 }
 
-// https://github.com/HB9UF/unconfusion
+// Log defines the data of a WiresX logentry, see also https://github.com/HB9UF/unconfusion
 type Log struct {
 	Callsign    string
 	Dev         Device
@@ -64,6 +65,7 @@ type Log struct {
 	Loc         *Location
 }
 
+// Location defines a position with longitude and latitude
 type Location struct {
 	Lat float64
 	Lon float64
@@ -156,6 +158,7 @@ func parseLogline(line string, timeLoc *time.Location) (*Log, error) {
 	}, nil
 }
 
+// TailLog tails the logfile to parse the loglines and returns log entries into a channel
 func TailLog(path string, ingestWholeFile bool, loc *time.Location, logChan chan *Log) error {
 	whence := io.SeekEnd
 	if ingestWholeFile {

--- a/wiresx2influx.go
+++ b/wiresx2influx.go
@@ -43,9 +43,9 @@ func main() {
 
 	// Feed InfluxDB
 	client := influxdb2.NewClient(conf.Influx.Server, conf.Influx.AuthToken)
-	writeApi := client.WriteApiBlocking(conf.Influx.Organization, conf.Influx.Bucket)
+	writeAPI := client.WriteApiBlocking(conf.Influx.Organization, conf.Influx.Bucket)
 	go func() {
-		influx.Feed(ctx, logChan, writeApi, map[string]string{
+		influx.Feed(ctx, logChan, writeAPI, map[string]string{
 			"repeater": conf.Influx.Repeater,
 		})
 	}()


### PR DESCRIPTION
Adds a GitHub Action to run unit tests and code linting.
Linting is only run on Linux, but unit tests are run for Linux, Mac and Windows (so we cover our target platform 🙂).

Fixed the warnings from the linters (mostly missing comments on exported functions and use of some deprecated APIs).

Comes with a simple unit test for the config parsing, the more interesting parts for testing will be the WiresX log parsing.